### PR TITLE
refactor: :lock: Domain Authority well known URL is part of App Confi…

### DIFF
--- a/web/staticwebapp.config.json
+++ b/web/staticwebapp.config.json
@@ -79,7 +79,7 @@
                 "clientSecretSettingName": "AUTH_CLIENT_SECRET"
               },
               "openIdConnectConfiguration": {
-                "wellKnownOpenIdConfiguration": "https://developerday-ind.us.auth0.com/.well-known/openid-configuration"
+                "wellKnownOpenIdConfiguration": "DOMAIN_AUTHORITY"
               }
             },
             "login": {


### PR DESCRIPTION
…guration

App Configuration cannot be supplied as a placeholder for part of a URL => Our workaround is to put the whole well know URL in the App configuration

Fixes #12